### PR TITLE
Added option to not skip first number of episodes in viewing session

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Features
   - Chapters
 - Only skip for watched content
 - Ignore skipping series and season premieres
+- Ignore skipping first episodes in every new viewing session
 - Skip last chapter (credits)
 - Bypass the "Up Next" screen
 - Custom Definitions

--- a/resources/settings.py
+++ b/resources/settings.py
@@ -69,6 +69,8 @@ class Settings:
             "unwatched": True,
             "first-episode-series": "Watched",
             "first-episode-season": "Always",
+            "subsequent-session-episodes": False,
+            "session-length": 120,
             "next": False
         },
         "Offsets": {
@@ -146,6 +148,8 @@ class Settings:
         self.skipunwatched: bool = False
         self.skipE01: Settings.SKIP_TYPES = Settings.SKIP_TYPES.ALWAYS
         self.skipS01E01: Settings.SKIP_TYPES = Settings.SKIP_TYPES.ALWAYS
+        self.skipSubsequentSessionEpisodes: bool = False
+        self.sessionLength: int = 120
         self.skipnext: bool = False
         self.leftOffset: int = 0
         self.rightOffset: int = 0
@@ -306,6 +310,8 @@ class Settings:
             self.skipE01 = self.SKIP_MATCHER.get(config.getboolean("Skip", "first-episode-season"))  # Legacy bool support
         except ValueError:
             self.skipE01 = self.SKIP_MATCHER.get(config.get("Skip", "first-episode-season").lower(), self.SKIP_TYPES.ALWAYS)
+        self.skipSubsequentSessionEpisodes = self.SKIP_MATCHER.get(config.getboolean("Skip", "subsequent-session-episodes"))
+        self.sessionLength = config.getint("Skip", "session-length")
         self.skipnext = config.getboolean("Skip", "next")
 
         self.leftOffset = config.getint("Offsets", "start")

--- a/resources/settings.py
+++ b/resources/settings.py
@@ -69,7 +69,7 @@ class Settings:
             "unwatched": True,
             "first-episode-series": "Watched",
             "first-episode-season": "Always",
-            "subsequent-session-episodes": False,
+            "subsequent-session-episodes-after": 0,
             "session-length": 120,
             "next": False
         },
@@ -148,7 +148,7 @@ class Settings:
         self.skipunwatched: bool = False
         self.skipE01: Settings.SKIP_TYPES = Settings.SKIP_TYPES.ALWAYS
         self.skipS01E01: Settings.SKIP_TYPES = Settings.SKIP_TYPES.ALWAYS
-        self.skipSubsequentSessionEpisodes: bool = False
+        self.skipSubsequentSessionEpisodesAfter: int = 0
         self.sessionLength: int = 120
         self.skipnext: bool = False
         self.leftOffset: int = 0
@@ -310,7 +310,7 @@ class Settings:
             self.skipE01 = self.SKIP_MATCHER.get(config.getboolean("Skip", "first-episode-season"))  # Legacy bool support
         except ValueError:
             self.skipE01 = self.SKIP_MATCHER.get(config.get("Skip", "first-episode-season").lower(), self.SKIP_TYPES.ALWAYS)
-        self.skipSubsequentSessionEpisodes = self.SKIP_MATCHER.get(config.getboolean("Skip", "subsequent-session-episodes"))
+        self.skipSubsequentSessionEpisodesAfter = config.getint("Skip", "subsequent-session-episodes-after")
         self.sessionLength = config.getint("Skip", "session-length")
         self.skipnext = config.getboolean("Skip", "next")
 

--- a/resources/skipper.py
+++ b/resources/skipper.py
@@ -3,6 +3,7 @@
 import logging
 import time
 import os
+from datetime import datetime, timedelta
 from resources.settings import Settings
 from resources.customEntries import CustomEntries
 from resources.sslAlertListener import SSLAlertListener
@@ -17,6 +18,7 @@ from plexapi.client import PlexClient
 from plexapi.server import PlexServer
 from plexapi.playqueue import PlayQueue
 from plexapi.base import PlexSession
+from plexapi.video import Show
 from threading import Thread
 from typing import Dict, List
 from pkg_resources import parse_version
@@ -73,6 +75,7 @@ class Skipper():
         self.verbose = os.environ.get("PAS_VERBOSE", "").lower() == "true"
 
         self.media_sessions: Dict[str, MediaWrapper] = {}
+        self.medias_in_session: Dict[int, Dict[Show, datetime]] = {}
         self.delete: List[str] = []
         self.ignored: List[str] = []
         self.reconnect: bool = True
@@ -83,7 +86,9 @@ class Skipper():
         self.log.debug("Skip tags %s" % (self.settings.tags))
         self.log.debug("Skip S01E01 %s" % (self.settings.skipS01E01))
         self.log.debug("Skip S**E01 %s" % (self.settings.skipE01))
+        self.log.debug("Skip subsequent session episodes %s" % (self.settings.skipSubsequentSessionEpisodes))
         self.log.debug("Skip last chapter %s" % (self.settings.skiplastchapter))
+        self.log.debug("Session length %s" % (self.settings.sessionLength))
 
         if settings.customEntries.needsGuidResolution:
             self.log.debug("Custom entries contain GUIDs that need ratingKey resolution")
@@ -108,6 +113,7 @@ class Skipper():
             try:
                 for session in list(self.media_sessions.values()):
                     self.checkMedia(session)
+                self.clearEndedSessions()
                 time.sleep(1)
             except KeyboardInterrupt:
                 self.log.debug("Stopping listener")
@@ -215,6 +221,48 @@ class Skipper():
                 self.log.debug("Inside marker %s for media %s with range %d(+%d)-%d(+%d) and viewOffset %d, volume should be low" % (marker.type, mediaWrapper, marker.start, lo, marker.end, ro, mediaWrapper.viewOffset))
                 return True
         return False
+
+    def isSubsequentSessionEpisode(self, mediaWrapper: MediaWrapper) -> bool:
+        media = mediaWrapper.plexsession.source()
+        if media.type == "movie":
+            self.log.debug("Media %s is of type '%s' and is being ignored" % (media, media.type))
+            return True  # True ensures movies are always ignored
+
+        if media.type in {"season", "episode"}:
+            self.log.debug("Media %s is of type '%s', retreiving parent media %s" % (media, media.type, media.show()))
+            media = media.show()
+
+        userID = mediaWrapper.plexsession.user.id
+        if userID not in self.medias_in_session:
+            self.log.debug("No previous media detected for userID [REDACTED], starting monitoring for user")
+            self.medias_in_session[userID] = {}
+
+        if media in self.medias_in_session[userID]:
+            if datetime.now() < self.medias_in_session[userID][media] + timedelta(minutes=self.settings.sessionLength):
+                self.log.debug("Media %s has reset its timer of %s minutes due to new instance being viewed" % (media, self.settings.sessionLength))
+                self.medias_in_session[userID][media] = datetime.now()  # Reset the time
+                return True  # Subsequent episode within the time period
+        else:
+            self.log.debug("Media %s is now being tracked for subsequent viewing for the next %s minutes" % (media, self.settings.sessionLength))
+            self.medias_in_session[userID] = {media: datetime.now()}  # First episode of the session
+        return False
+
+    def clearEndedSessions(self) -> None:
+        userIDsToDelete = []
+        for userID in self.medias_in_session:
+            self.medias_in_session[userID] = self.medias_in_session[userID]
+            mediaToDelete = []
+            for media in self.medias_in_session[userID]:
+                if datetime.now() >= self.medias_in_session[userID][media] + timedelta(minutes=self.settings.sessionLength):
+                    mediaToDelete.append(media)
+            for media in mediaToDelete:
+                self.log.debug("Media %s has not been watched in %s minutes and is no longer being tracked for subsequent viewing" % (media, self.settings.sessionLength))
+                self.medias_in_session[userID].pop(media)
+            if not self.medias_in_session[userID]:
+                userIDsToDelete.append(userID)
+        for userID in userIDsToDelete:
+            self.log.debug("UserID [REDACTED] has not been watched any media %s minutes and is no longer being tracked for subsequent viewing" % (self.settings.sessionLength))
+            self.medias_in_session.pop(userID)
 
     def seekTo(self, mediaWrapper: MediaWrapper, targetOffset: int) -> None:
         t = Thread(target=self._seekTo, args=(mediaWrapper, targetOffset,))
@@ -451,8 +499,13 @@ class Skipper():
                     self.log.debug("Blocking %s, first episode in series and skip-first-episode-series is %s" % (mediaWrapper, self.settings.skipS01E01))
                     return False
                 elif self.settings.skipS01E01 == Settings.SKIP_TYPES.WATCHED and not media.isWatched:
-                    self.log.debug("Blocking %s first episode in series and skip-first-episode-series is %s and isWatched %s" % (mediaWrapper, self.settings.skipS01E01, media.isWatched))
+                    self.log.debug("Blocking %s, first episode in series and skip-first-episode-series is %s and isWatched %s" % (mediaWrapper, self.settings.skipS01E01, media.isWatched))
                     return False
+
+        # Session episodes
+        if self.settings.skipSubsequentSessionEpisodes == Settings.SKIP_TYPES.ALWAYS and not self.isSubsequentSessionEpisode(mediaWrapper):
+            self.log.debug("Blocking %s, first episode in session and skip-subsequent-session-episodes is %s" % (mediaWrapper, self.settings.skipSubsequentSessionEpisodes))
+            return False
 
         # Keys
         allowed = False

--- a/resources/skipper.py
+++ b/resources/skipper.py
@@ -250,7 +250,6 @@ class Skipper():
     def clearEndedSessions(self) -> None:
         userIDsToDelete = []
         for userID in self.medias_in_session:
-            self.medias_in_session[userID] = self.medias_in_session[userID]
             mediaToDelete = []
             for media in self.medias_in_session[userID]:
                 if datetime.now() >= self.medias_in_session[userID][media] + timedelta(minutes=self.settings.sessionLength):
@@ -261,7 +260,7 @@ class Skipper():
             if not self.medias_in_session[userID]:
                 userIDsToDelete.append(userID)
         for userID in userIDsToDelete:
-            self.log.debug("UserID [REDACTED] has not been watched any media %s minutes and is no longer being tracked for subsequent viewing" % (self.settings.sessionLength))
+            self.log.debug("UserID [REDACTED] has not watched any media in %s minutes and is no longer being tracked for subsequent viewing" % (self.settings.sessionLength))
             self.medias_in_session.pop(userID)
 
     def seekTo(self, mediaWrapper: MediaWrapper, targetOffset: int) -> None:

--- a/setup/config.ini.sample
+++ b/setup/config.ini.sample
@@ -21,6 +21,8 @@ last-chapter = 0.0
 unwatched = True
 first-episode-series = Watched
 first-episode-season = Always
+subsequent-session-episodes-after = 1
+session-length = 120
 next = False
 
 [Offsets]


### PR DESCRIPTION
Per issue #37.

Added two config options:
subsequent-session-episodes = False
session-length = 120

If False, it's default behavior. If True, it will never skip the first episode at the start of a viewing session. After session-length (minutes), a session is considered over unless if the same user starts another episode (or the same) of the exact same show. Timer resets each new episode. Movies are ignored.

Logging is all debug. I've tested it and it's working as expected.

Note: The subsequent episodes are always handled elsewhere. Only the first episode of a session has whether or not it will be skipped changed.